### PR TITLE
Remove GPA Calc URLs

### DIFF
--- a/certs.sh
+++ b/certs.sh
@@ -15,8 +15,6 @@ faculty-roles-staging.umn.edu
 faculty-roles.umn.edu
 forseti-staging.umn.edu
 forseti.umn.edu
-gpacalc-staging.umn.edu
-gpacalc.umn.edu
 onestop-queue-staging.umn.edu
 onestop-queue.umn.edu
 our-stg.umn.edu


### PR DESCRIPTION
Removing the GPA calc URLs because these servers have been decommissioned.